### PR TITLE
Updated Core.Py to remove logic in setup_skills function.

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -257,17 +257,6 @@ class OpsDroid:
                     func.config = skill["config"]
                     self.skills.append(func)
 
-        with contextlib.suppress(AttributeError):
-            for skill in skills:
-                skill["module"].setup(self, self.config)
-                _LOGGER.warning(
-                    _(
-                        "<skill module>.setup() is deprecated and "
-                        "will be removed in a future release. "
-                        "Please use class-based skills instead."
-                    )
-                )
-
     async def train_parsers(self, skills):
         """Train the parsers."""
         if "parsers" in self.config:


### PR DESCRIPTION
Removed the following logic in def setup_skills(self, skills):
(This is done to remove the deprecation warning to function based skills)

        with contextlib.suppress(AttributeError):
            for skill in skills:
                skill["module"].setup(self, self.config)
                _LOGGER.warning(
                    _(
                        "<skill module>.setup() is deprecated and "
                        "will be removed in a future release. "
                        "Please use class-based skills instead."
                    )
                )

# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

Fixes #<issue>


## Status
**READY** | **UNDER DEVELOPMENT** | **ON HOLD**


## Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Documentation (fix or adds documentation)


# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration._

- Test A
- Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

